### PR TITLE
Adding support for Kohana 3.2 and ORM.

### DIFF
--- a/classes/useradmin/controller/admin/user.php
+++ b/classes/useradmin/controller/admin/user.php
@@ -226,8 +226,7 @@ class Useradmin_Controller_Admin_User extends Controller_App {
 				// Delete the user
 				$user->delete($id);
 				// Delete any associated identities
-				DB::delete('user_identity')->where('user_id', '=', $id)
-				                           ->execute();
+				ORM::factory('user_identity')->where(array('user_id' => $id))->delete_all();
 				// message: save success
 				Message::add('success', __('User deleted.'));
 			}

--- a/classes/useradmin/controller/user.php
+++ b/classes/useradmin/controller/user.php
@@ -275,8 +275,7 @@ class Useradmin_Controller_User extends Controller_App {
 			// Delete the user
 			$user->delete($id);
 			// Delete any associated identities
-			DB::delete('user_identity')->where('user_id', '=', $id)
-			                           ->execute();
+			ORM::factory('user_identity')->where(array('user_id' => $id))->delete_all();
 			// message: save success
 			Message::add('success', __('User deleted.'));
 			$this->request->redirect(Session::instance()->get_once('returnUrl','user/profile'));
@@ -541,6 +540,8 @@ class Useradmin_Controller_User extends Controller_App {
 	 */
 	function action_provider ($provider_name = null)
 	{
+		$provider_name = $this->request->param('provider', $provider_name);
+
 		if (Auth::instance()->logged_in())
 		{
 			Message::add('success', 'Already logged in.');
@@ -566,11 +567,13 @@ class Useradmin_Controller_User extends Controller_App {
 
 	function action_associate($provider_name = null)
 	{
-	if ($this->request->query('code') && $this->request->query('state'))
-	{
-		$this->action_associate_return($provider_name);
-		return;
-	}
+		$provider_name = $this->request->param('provider', $provider_name);
+		
+		if ($this->request->query('code') && $this->request->query('state'))
+		{
+			$this->action_associate_return($provider_name);
+			return;
+		}
 		if (Auth::instance()->logged_in())
 		{
 			if (isset($_POST['confirmation']) && $_POST['confirmation'] == 'Y')
@@ -626,6 +629,8 @@ class Useradmin_Controller_User extends Controller_App {
 	 */
 	function action_associate_return($provider_name = null)
 	{
+		$provider_name = $this->request->param('provider', $provider_name);
+
 		if (Auth::instance()->logged_in())
 		{
 			$provider = Provider::factory($provider_name);
@@ -670,6 +675,8 @@ class Useradmin_Controller_User extends Controller_App {
 	 */
 	function action_provider_return($provider_name = null)
 	{
+		$provider_name = $this->request->param('provider', $provider_name);
+		
 		$provider = Provider::factory($provider_name);
 		if (! is_object($provider))
 		{

--- a/init.php
+++ b/init.php
@@ -1,17 +1,14 @@
 <?php defined('SYSPATH') or die('No direct access allowed.');
 
-Route::set('user/provider', 'user/provider(/<provider>)', array('provider' => '.+'))
+Route::set('user-default', 'user(/<action>(/<provider>))',
+	array(
+		'action' => '(provider|provider_return|associate|associate_return)',
+		'provider' => '.+',
+	))
 	->defaults(array(
 		'controller' => 'user',
-		'action'     => 'provider',
-		'provider'       => NULL,
-	));
-
-Route::set('user/provider_return', 'user/provider_return(/<provider>)', array('provider' => '.+'))
-	->defaults(array(
-		'controller' => 'user',
-		'action'     => 'provider_return',
-		'provider'       => NULL,
+		'action'     => 'index',
+		'provider'   => NULL,
 	));
 
 // Static file serving (CSS, JS, images)
@@ -22,4 +19,3 @@ Route::set('css', '<dir>(/<file>)', array('file' => '.+', 'dir' => '(css|img)'))
 		'file'       => NULL,
 		'dir'       => NULL,
 	));
-

--- a/messages/register/user.php
+++ b/messages/register/user.php
@@ -10,6 +10,7 @@ return array(
          'email' => 'This is not a valid email.', // Workaround for Bug Report #3750
          'email_available' => 'This email address is already in use.',
          'email_not_unique' => 'This email address is already in use.',
+         'unique' => 'This email address is already in use.',
        ),
       'email_confirm' => array(
          'email' => 'This is not a valid email.', // Workaround for Bug Report #3750

--- a/schema.sql
+++ b/schema.sql
@@ -69,13 +69,13 @@ INSERT INTO `roles_users` (`user_id`, `role_id`) VALUES
 -- --------------------------------------------------------
 
 --
--- Table structure for table `user_identity`
+-- Table structure for table `user_identities`
 --
 
-DROP TABLE IF EXISTS `user_identity`;
+DROP TABLE IF EXISTS `user_identities`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `user_identity` (
+CREATE TABLE `user_identities` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` int(11) NOT NULL,
   `provider` varchar(255) NOT NULL,


### PR DESCRIPTION
 Deleting user_identity via ORM instead of DB directly.
 Adding request->param support for the following user controller actions:
   action_provider
   action_provider_return
   action_associate
   action_associate_return
 Adding new route that works with the above actions.
 Adding a proper duplicate email message.
 Renaming the user_identity table to user_identities.
