### PR TITLE
Update tests/usertests.php

### DIFF
--- a/tests/usertests.php
+++ b/tests/usertests.php
@@ -12,7 +12,7 @@
  * @author     gabrielgiannattasio <gabriel@l6.com.br>
  * @copyright  (c) 2011-2011 Fleep.me
  */
-class UserTests extends Unittest_Model_TestCase {
+class UserTests extends Unittest_TestCase {
 	
 	private function add_valid_users()
 	{


### PR DESCRIPTION
Unittest_Model_TestCase does not seem to exist in Kohana 3.2. PHPUnit was failing.
phpunit --bootstrap=modules/unittest/bootstrap.php modules/unittest/tests.php
PHP Fatal error:  Class 'Unittest_Model_TestCase' not found in /path/to/kohana/modules/user/tests/usertests.php on line 15
